### PR TITLE
Updates the BouncyCastle package reference

### DIFF
--- a/src/Certes/Certes.csproj
+++ b/src/Certes/Certes.csproj
@@ -42,12 +42,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" Condition="'$(TargetFramework)' == 'net462'" />
   </ItemGroup>
 

--- a/src/Certes/Pkcs/PfxBuilder.cs
+++ b/src/Certes/Pkcs/PfxBuilder.cs
@@ -111,7 +111,7 @@ namespace Certes.Pkcs
                     Cert = cert
                 });
 
-            var rootCerts = new HashSet(certificates.Where(c => c.IsRoot).Select(c => new TrustAnchor(c.Cert, null)));
+            var rootCerts = new HashSet<TrustAnchor>(certificates.Where(c => c.IsRoot).Select(c => new TrustAnchor(c.Cert, null)));
             var intermediateCerts = certificates.Where(c => !c.IsRoot).Select(c => c.Cert).ToList();
             intermediateCerts.Add(certificate);
 
@@ -125,10 +125,8 @@ namespace Certes.Pkcs
                 IsRevocationEnabled = false
             };
 
-            builderParams.AddStore(
-                X509StoreFactory.Create(
-                    "Certificate/Collection",
-                    new X509CollectionStoreParameters(intermediateCerts)));
+            var x509CertStore = CollectionUtilities.CreateStore(intermediateCerts);
+            builderParams.AddStoreCert(x509CertStore);
 
             var builder = new PkixCertPathBuilder();
             var result = builder.Build(builderParams);


### PR DESCRIPTION
Updates the package reference from Portable.BouncyCastle to BouncyCastle.Cryptography

## Description

Certes currently uses BouncyCastle via the Portable.BouncyCastle [nuget package](https://www.nuget.org/packages/Portable.BouncyCastle). This package was created and maintained separately from the BouncyCastle team, which did not have an official nuget distribution compatible with .NET Core. That package has not been updated since October 2021, and no further updates are expected.

This update changes the reference from Portable.BouncyCastle to BouncyCastle.Cryptography, which is the official package maintained by the BouncyCastle team.

## Checklist

- [ ] All tests are passing
- [ ] New tests were created to address changes in pr (and tests are passing)
- [ ] Updated README and/or documentation, if necessary

Thanks for contributing!
